### PR TITLE
point_spotlight brightness field & input

### DIFF
--- a/fgd/point/point/point_spotlight.fgd
+++ b/fgd/point/point/point_spotlight.fgd
@@ -18,13 +18,14 @@
 	hdrcolorscale(float) : "HDR color scale." : "0.7" : "float value to multiply sprite color by when running in HDR mode."
 	haloscale[since_L4D2](float) : "Halo size scale." : 60 : "float value to determine the size of the halo."
 	ignoresolid[TF2](boolean) : "Ignore Solid" : 0 : "If set, this spotlight won't trace for solids."
-
+	brightness[P2CE](integer) : "Brightness" : 64 : "Integer value representing spotlight brightness (0-255)"
 
 	// Inputs
 	input LightOn(void) : "Turn the spotlight on."
 	input LightOff(void) : "Turn the spotlight off"
 	input SetColor[since_ASW, GMod](color255) : "Change the color of the spotlight."
 	input ForceUpdate[since_ASW, GMod](void) : "Force an update of the spotlight position and orientation."
+	input SetBrightness[P2CE](integer) : "Set the brightness of the spotlight."
 
 	// Outputs
 	output OnLightOn(void) : "Fires when light turns on."


### PR DESCRIPTION
Companion PR to an internal one fixing default spotlight brightness (https://github.com/momentum-mod/game/issues/1211)

This adds brightness as a field & an input for it; can now dynamically change `point_spotlight` brightness: https://cdn.discordapp.com/attachments/439686613036171265/816940897941717002/2021-03-03_23-49-42.mp4

Just for P2CE right now as momentum still needs to be added to this repo (still using our FGD's from our SDK2013 build).